### PR TITLE
Overwrite existing inner class info from JSON.

### DIFF
--- a/src/main/java/de/oceanlabs/mcp/mcinjector/JsonAttributeClassAdaptor.java
+++ b/src/main/java/de/oceanlabs/mcp/mcinjector/JsonAttributeClassAdaptor.java
@@ -47,6 +47,12 @@ public class JsonAttributeClassAdaptor extends ClassVisitor
             case ACC_PUBLIC: ret |= ACC_PUBLIC; break;
         }
 
+        // Unset final bit if they are different (one final, one not-final)
+        if (((access1 & ACC_FINAL) ^ (access2 & ACC_FINAL)) == 1)
+        {
+            ret &= ~ACC_FINAL;
+        }
+
         return ret;
     }
 

--- a/src/main/java/de/oceanlabs/mcp/mcinjector/JsonAttributeClassAdaptor.java
+++ b/src/main/java/de/oceanlabs/mcp/mcinjector/JsonAttributeClassAdaptor.java
@@ -7,6 +7,8 @@ import java.util.logging.Logger;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
 
+import static org.objectweb.asm.Opcodes.*;
+
 public class JsonAttributeClassAdaptor extends ClassVisitor
 {
     private static final Logger log = Logger.getLogger("MCInjector");
@@ -31,11 +33,42 @@ public class JsonAttributeClassAdaptor extends ClassVisitor
         visitedInners.clear();
         super.visit(version, access, name, signature, superName, interfaces);
     }
-    
+
+    private int mostVisibleAccess(int access1, int access2)
+    {
+        int ret = access1 & ~7;
+        int t = access2 & 7;
+
+        switch (access1 & 7)
+        {
+            case ACC_PRIVATE: ret |= t; break;
+            case 0: ret |= (t != ACC_PRIVATE ? t : 0); break;
+            case ACC_PROTECTED: ret |= (t != ACC_PRIVATE && t != 0 ? t : ACC_PROTECTED); break;
+            case ACC_PUBLIC: ret |= ACC_PUBLIC; break;
+        }
+
+        return ret;
+    }
+
     @Override
     public void visitInnerClass(String name, String outerName, String innerName, int access)
     {
         visitedInners.add(name);
+
+        if (json != null && json.innerClasses != null)
+        {
+            for (JsonStruct.InnerClass inner : json.innerClasses)
+            {
+                if (inner.inner_class.equals(name))
+                {
+                    int newAccess = mostVisibleAccess(access, inner.getAccess());
+                    log.fine("Overwriting Inner Class: " + name +  " -> " + inner.inner_class + " " + access + " -> " + newAccess + " " + outerName + " -> " + inner.outer_class + " " + innerName + " -> " + inner.inner_name);
+                    super.visitInnerClass(inner.inner_class, inner.outer_class, inner.inner_name, newAccess);
+                    return;
+                }
+            }
+        }
+
         super.visitInnerClass(name, outerName, innerName, access);
     }
 
@@ -43,6 +76,18 @@ public class JsonAttributeClassAdaptor extends ClassVisitor
     public void visitOuterClass(String owner, String name, String desc)
     {
         visitedOuter = true;
+
+        if (json != null && json.enclosingMethod != null)
+        {
+            JsonStruct.EnclosingMethod enc = json.enclosingMethod;
+            if (enc != null && !visitedOuter && enc.name != null && enc.desc != null)
+            {
+                log.fine("Overwriting Outer Class: " + owner + " -> " + enc.owner + " " + name + " -> " + enc.name + " " + desc + " -> " + enc.desc);
+                super.visitOuterClass(enc.owner, enc.name, enc.desc);
+                return;
+            }
+        }
+
         super.visitOuterClass(owner, name, desc);
     }
 


### PR DESCRIPTION
By ignoring any pre-existing inner class info attempts to edit it,
such as by ForgeGradle handing AccessTransformers on inner classes,
gets ignored.

Some inner classes still work, but many anonymous ones, and some named
inner classes such as the GuiContainerCreative ones have pre-existing
inner class info for some reason.

(This seems to be every inner class in the JSON supplied by Forge with
a "start" attribute)
