### PR TITLE
Add ParameterAnnotationFixer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,12 @@ repositories {
 
 jar {
     manifest.attributes('Main-Class': 'de.oceanlabs.mcp.mcinjector.MCInjector')
+    manifest.attributes('Implementation-Version': project.version)
 }
 shadowJar {
     classifier 'fatjar'
     manifest.attributes('Main-Class': 'de.oceanlabs.mcp.mcinjector.MCInjector')
+    manifest.attributes('Implementation-Version': project.version)
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ artifacts {
 }
 
 dependencies {
-    compile 'org.ow2.asm:asm:6.0'
-    compile 'org.ow2.asm:asm-tree:6.0'
+    compile 'org.ow2.asm:asm:6.1-beta2'
+    compile 'org.ow2.asm:asm-tree:6.1-beta2'
     compile 'net.sf.jopt-simple:jopt-simple:4.5'
     compile 'com.google.code.gson:gson:2.2.4'
 }

--- a/src/main/java/de/oceanlabs/mcp/mcinjector/MCInjector.java
+++ b/src/main/java/de/oceanlabs/mcp/mcinjector/MCInjector.java
@@ -12,7 +12,14 @@ import joptsimple.OptionSet;
 public class MCInjector
 {
     private final static Logger log = Logger.getLogger("MCInjector");
-    public static final String VERSION = "MCInjector v3.4 by Searge, LexManos, Fesh0r";
+    public static final String VERSION;
+    static {
+        String implVersion = MCInjector.class.getPackage().getImplementationVersion();
+        if (implVersion == null) {
+            implVersion = "Unknown";
+        }
+        VERSION = "MCInjector v" + implVersion + " by Searge, LexManos, Fesh0r";
+    }
 
     public static void main(String[] args) throws Exception
     {

--- a/src/main/java/de/oceanlabs/mcp/mcinjector/MCInjectorImpl.java
+++ b/src/main/java/de/oceanlabs/mcp/mcinjector/MCInjectorImpl.java
@@ -48,6 +48,7 @@ import de.oceanlabs.mcp.mcinjector.adaptors.JsonAttribute;
 import de.oceanlabs.mcp.mcinjector.adaptors.LVTFernflower;
 import de.oceanlabs.mcp.mcinjector.adaptors.LVTLvt;
 import de.oceanlabs.mcp.mcinjector.adaptors.LVTStrip;
+import de.oceanlabs.mcp.mcinjector.adaptors.ParameterAnnotationFixer;
 import de.oceanlabs.mcp.mcinjector.adaptors.ReadMarker;
 
 public class MCInjectorImpl
@@ -638,6 +639,8 @@ public class MCInjectorImpl
             }
 
             ca = new AccessFixer(ca, this);
+
+            ca = new ParameterAnnotationFixer(ca, this);
         }
         ca = new AccessReader(ca, this);
 

--- a/src/main/java/de/oceanlabs/mcp/mcinjector/adaptors/ParameterAnnotationFixer.java
+++ b/src/main/java/de/oceanlabs/mcp/mcinjector/adaptors/ParameterAnnotationFixer.java
@@ -1,0 +1,198 @@
+package de.oceanlabs.mcp.mcinjector.adaptors;
+
+import static org.objectweb.asm.Opcodes.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InnerClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import de.oceanlabs.mcp.mcinjector.MCInjectorImpl;
+
+public class ParameterAnnotationFixer extends ClassVisitor
+{
+    private static final Logger LOGGER = Logger.getLogger("MCInjector");
+
+    public ParameterAnnotationFixer(ClassVisitor cn, MCInjectorImpl mci)
+    {
+        super(Opcodes.ASM5, cn);
+    }
+
+    @Override
+    public void visitEnd()
+    {
+        super.visitEnd();
+
+        ClassNode cls = MCInjectorImpl.getClassNode(cv);
+        Type[] syntheticParams = getExpectedSyntheticParams(cls);
+        if (syntheticParams != null)
+        {
+            for (MethodNode mn : cls.methods)
+            {
+                if (mn.name.equals("<init>"))
+                {
+                    processConstructor(cls, mn, syntheticParams);
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if the given class might have synthetic parameters in the
+     * constructor. There are two cases where this might happen:
+     * <ol>
+     * <li>If the given class is an inner class, the first parameter is the
+     * instance of the outer class.</li>
+     * <li>If the given class is an enum, the first parameter is the enum
+     * constant name and the second parameter is its ordinal.</li>
+     * </ol>
+     *
+     * @return An array of types for synthetic parameters if the class can have
+     *         synthetic parameters, otherwise null.
+     */
+    private Type[] getExpectedSyntheticParams(ClassNode cls)
+    {
+        // Check for enum
+        // http://hg.openjdk.java.net/jdk8/jdk8/langtools/file/1ff9d5118aae/src/share/classes/com/sun/tools/javac/comp/Lower.java#l2866
+        if ((cls.access & ACC_ENUM) != 0)
+        {
+            LOGGER.fine("  Considering " + cls.name
+                    + " for extra parameter annotations as it is an enum");
+            return new Type[] { Type.getObjectType("java/lang/String"), Type.INT_TYPE };
+        }
+
+        // Check for inner class
+        InnerClassNode info = null;
+        for (InnerClassNode node : cls.innerClasses) // note: cls.innerClasses is never null
+        {
+            if (node.name.equals(cls.name))
+            {
+                info = node;
+                break;
+            }
+        }
+        // http://hg.openjdk.java.net/jdk8/jdk8/langtools/file/1ff9d5118aae/src/share/classes/com/sun/tools/javac/code/Symbol.java#l398
+        if (info == null)
+        {
+            LOGGER.fine("  Not considering " + cls.name
+                    + " for extra parameter annotations as it is not an inner class");
+            return null; // It's not an inner class
+        }
+        if ((info.access & (ACC_STATIC | ACC_INTERFACE)) != 0)
+        {
+            LOGGER.fine("  Not considering " + cls.name
+                    + " for extra parameter annotations as is an interface or static");
+            return null; // It's static or can't have a constructor
+        }
+
+        // http://hg.openjdk.java.net/jdk8/jdk8/langtools/file/1ff9d5118aae/src/share/classes/com/sun/tools/javac/jvm/ClassReader.java#l2011
+        if (info.innerName == null)
+        {
+            LOGGER.fine("  Not considering " + cls.name
+                    + " for extra parameter annotations as it is annonymous");
+            return null; // It's an anonymous class
+        }
+
+        LOGGER.fine("  Considering " + cls.name
+                + " for extra parameter annotations as it is an inner class of "
+                + info.outerName);
+
+        return new Type[] { Type.getObjectType(info.outerName) };
+    }
+
+    /**
+     * Removes the parameter annotations for the given synthetic parameters,
+     * if there are parameter annotations and the synthetic parameters exist.
+     */
+    private void processConstructor(ClassNode cls, MethodNode mn, Type[] syntheticParams) {
+        String methodInfo = mn.name + mn.desc + " in " + cls.name;
+        Type[] params = Type.getArgumentTypes(mn.desc);
+
+        if (beginsWith(params, syntheticParams))
+        {
+            mn.visibleParameterAnnotations = process(methodInfo,
+                    "RuntimeVisibleParameterAnnotations", params.length,
+                    syntheticParams.length, mn.visibleParameterAnnotations);
+            mn.invisibleParameterAnnotations = process(methodInfo,
+                    "RuntimeInvisibleParameterAnnotations", params.length,
+                    syntheticParams.length, mn.invisibleParameterAnnotations);
+        }
+        else
+        {
+            LOGGER.warning("Unexpected lack of synthetic args to the constructor: expected "
+                            + Arrays.toString(syntheticParams) + " at the start of " + methodInfo);
+        }
+    }
+
+    private boolean beginsWith(Type[] values, Type[] prefix)
+    {
+        if (values.length < prefix.length)
+        {
+            return false;
+        }
+        for (int i = 0; i < prefix.length; i++)
+        {
+            if (!values[i].equals(prefix[i]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Removes annotation nodes corresponding to synthetic parameters, after
+     * the existence of synthetic parameters has already been checked.
+     *
+     * @param methodInfo
+     *            A description of the method, for logging
+     * @param attributeName
+     *            The name of the attribute, for logging
+     * @param numParams
+     *            The number of parameters in the method
+     * @param numSynthetic
+     *            The number of synthetic parameters (should not be 0)
+     * @param annotations
+     *            The current array of annotation nodes, may be null
+     * @return The new array of annotation nodes, may be null
+     */
+    private List<AnnotationNode>[] process(String methodInfo,
+            String attributeName, int numParams, int numSynthetic,
+            List<AnnotationNode>[] annotations)
+    {
+        if (annotations == null)
+        {
+            LOGGER.finer("    " + methodInfo + " does not have a "
+                    + attributeName + " attribute");
+            return null;
+        }
+
+        int numAnnotations = annotations.length;
+        if (numParams == numAnnotations)
+        {
+            LOGGER.info("Found extra " + attributeName + " entries in "
+                    + methodInfo + ": removing " + numSynthetic);
+            return Arrays.copyOfRange(annotations, numSynthetic,
+                    numAnnotations);
+        }
+        else if (numParams == numAnnotations - numSynthetic)
+        {
+            LOGGER.info("Number of " + attributeName + " entries in "
+                    + methodInfo + " is already as we want");
+            return annotations;
+        }
+        else
+        {
+            LOGGER.warning("Unexpected number of " + attributeName
+                    + " entries in " + methodInfo + ": " + numAnnotations);
+            return annotations;
+        }
+    }
+}

--- a/src/main/java/de/oceanlabs/mcp/mcinjector/adaptors/ParameterAnnotationFixer.java
+++ b/src/main/java/de/oceanlabs/mcp/mcinjector/adaptors/ParameterAnnotationFixer.java
@@ -22,7 +22,17 @@ public class ParameterAnnotationFixer extends ClassVisitor
 
     public ParameterAnnotationFixer(ClassVisitor cn, MCInjectorImpl mci)
     {
-        super(Opcodes.ASM5, cn);
+        super(Opcodes.ASM6, cn);
+        // Extra version check, since these were added in ASM 6.1 and there
+        // isn't a constant for it
+        try {
+            MethodNode.class.getField("visibleAnnotableParameterCount");
+            MethodNode.class.getField("invisibleAnnotableParameterCount");
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(
+                    "AnnotableParameterCount fields are not present -- wrong ASM version?",
+                    ex);
+        }
     }
 
     @Override
@@ -123,6 +133,16 @@ public class ParameterAnnotationFixer extends ClassVisitor
             mn.invisibleParameterAnnotations = process(methodInfo,
                     "RuntimeInvisibleParameterAnnotations", params.length,
                     syntheticParams.length, mn.invisibleParameterAnnotations);
+            // ASM uses this value, not the length of the array
+            // Note that this was added in ASM 6.1
+            if (mn.visibleParameterAnnotations != null)
+            {
+                mn.visibleAnnotableParameterCount = mn.visibleParameterAnnotations.length;
+            }
+            if (mn.invisibleParameterAnnotations != null)
+            {
+                mn.invisibleAnnotableParameterCount = mn.invisibleParameterAnnotations.length;
+            }
         }
         else
         {


### PR DESCRIPTION
This fixes [`RuntimeVisibleParameterAnnotations`](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.18) and [`RuntimeInvisibleParameterAnnotations`](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.19) attributes to repair a case where ProGuard adds extra values for synthetic parameters (where the correct number of parameters is poorly defined).  See MinecraftForge/ForgeGradle#472.

This detects synthetic parameters by following the same logic the compiler uses to insert them.  There are two places where such synthetic parameters are added:

* Enums (for the name and ordinal), compiler source [here](http://hg.openjdk.java.net/jdk8/jdk8/langtools/file/1ff9d5118aae/src/share/classes/com/sun/tools/javac/comp/Lower.java#l2866) and also noted by CFR [here](http://www.benf.org/other/cfr/how-are-enums-implemented.html)
* Inner classes (for the synthetic parameter that references the outer class), compiler source [here](http://hg.openjdk.java.net/jdk8/jdk8/langtools/file/1ff9d5118aae/src/share/classes/com/sun/tools/javac/code/Symbol.java#l398) and also noted by CFR [here](http://www.benf.org/other/cfr/inner-class-fake-friends.html).  I exclude anonymous classes based off of [this info](http://hg.openjdk.java.net/jdk8/jdk8/langtools/file/1ff9d5118aae/src/share/classes/com/sun/tools/javac/jvm/ClassReader.java#l2008) in the compiler; it also appears that anonymous classes do not have info about the outer class so this is fine.

    This check does depend on having accurate [`InnerClasses`](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.6) information.  This has been provided since some time in 1.8 (at the same time, we started getting classes with `$` in the name obfuscated for inner classes, which is how it should be), and as such is available in all versions that have annotations.

While theoretically we could detect synthetic params in a much simpler manner by checking the [`MethodParameters`](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.24) attribute, Minecraft does not include that attribute.

[Here is a diff of the resulting changes](https://gist.github.com/Pokechu22/6794e62ca90c1d59d8e8ff526eec25c8).  There are two inner classes with constructors that have annotations on them: `SPacketPlayerListItem$AddPlayerData` and `RenderGlobal$ContainerLocalRenderInformation` (which was previously noticed in ModCoderPack/MCPBot-Issues#257).  There are no enums with constructors that have annotations on them.  This is the case for both Minecraft 1.12.2 (as shown in that diff) and 1.9.4 (only ran exceptor; determined by checking the output).