### PR TITLE
Switch back to ASM 5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'eclipse'
 apply plugin: 'maven'
 
 group = 'de.oceanlabs.mcp'
-version = '3.6'
+version = '3.6.1-SNAPSHOT'
 targetCompatibility = '1.6'
 sourceCompatibility = '1.6'
 
@@ -38,8 +38,7 @@ artifacts {
 }
 
 dependencies {
-    compile 'org.ow2.asm:asm:6.1-beta2'
-    compile 'org.ow2.asm:asm-tree:6.1-beta2'
+    compile 'org.ow2.asm:asm-debug-all:5.0.4'
     compile 'net.sf.jopt-simple:jopt-simple:4.5'
     compile 'com.google.code.gson:gson:2.2.4'
 }


### PR DESCRIPTION
This switches back to ASM version 5.0 while still maintaining the parameter annotation changes (#3).

This code is a bit hacky, because ASM actually did not provide a direct way to change the number of annotations until version 6.1.  However, we cannot use ASM 6.1 yet due to another change (reording of how attributes are output, which breaks forge's binary patches when used in ForgeGradle's `mergeJar` task).  Fortunately(ish) ASM had a system to mark extra annotation entries as synthetic (it actually generated and then removed those to work around the same javac "bug" that proguard tries to fix).  We can simply add the same marker, and then ASM will [remove the corresponding values](https://gitlab.ow2.org/asm/asm/blob/ASM_6_0/src/org/objectweb/asm/MethodWriter.java#L559-564) when [writing the parameter annotation tables](https://gitlab.ow2.org/asm/asm/blob/ASM_6_0/src/org/objectweb/asm/MethodWriter.java#L2137-2150).

This hack does _not_ work in ASM 6.1.  While I could have merged both together, I decided not to (and instead to explicitly make the code fail on ASM 6.1) because if ASM 6.1 is used for other reasons, then `mergeJar` will break.  In 1.13, I expect that we will switch to a newer version of MCInjector, and we can also switch to ASM 6.1 (and the previous 6.1-only implementation) at that time.